### PR TITLE
take into account lines preceded by ! in .gitignore file

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function parseGitignore(opts) {
   var gitignoreFile = findup('.gitignore', {cwd: cwd});
   var gitignorePatterns = ignore(gitignoreFile);
   var ignorePatterns = gitignorePatterns.filter(p => !p.startsWith('!'));
-  var exemptionPatterns = gitignorePatterns.filter(p => p.startsWith('!'));
+  var exemptionPatterns = gitignorePatterns.filter(p => p.startsWith('!')).map(p => p.substr(1));
 
   var isMatch = function(fp) {
     return !mm.any(fp, exemptionPatterns, opts) && mm.any(fp, ignorePatterns, opts);

--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ function parseGitignore(opts) {
   var gitignoreFile = findup('.gitignore', {cwd: cwd});
   var gitignorePatterns = ignore(gitignoreFile);
   var ignorePatterns = gitignorePatterns.filter(function(p) {
-    return !p.startsWith('!');
+    return p.charAt(0) !== '!';
   });
   var exemptionPatterns = gitignorePatterns.filter(function(p) {
-    return p.startsWith('!');
+    return p.charAt(0) === '!';
   }).map(function(p) {
     return p.substr(1);
   });

--- a/index.js
+++ b/index.js
@@ -10,8 +10,14 @@ function parseGitignore(opts) {
 
   var gitignoreFile = findup('.gitignore', {cwd: cwd});
   var gitignorePatterns = ignore(gitignoreFile);
-  var ignorePatterns = gitignorePatterns.filter(p => !p.startsWith('!'));
-  var exemptionPatterns = gitignorePatterns.filter(p => p.startsWith('!')).map(p => p.substr(1));
+  var ignorePatterns = gitignorePatterns.filter(function(p) {
+    return !p.startsWith('!');
+  });
+  var exemptionPatterns = gitignorePatterns.filter(function(p) {
+    return p.startsWith('!');
+  }).map(function(p) {
+    return p.substr(1);
+  });
 
   var isMatch = function(fp) {
     return !mm.any(fp, exemptionPatterns, opts) && mm.any(fp, ignorePatterns, opts);

--- a/index.js
+++ b/index.js
@@ -9,10 +9,12 @@ function parseGitignore(opts) {
   opts = opts || {};
 
   var gitignoreFile = findup('.gitignore', {cwd: cwd});
-  var ignorePatterns = ignore(gitignoreFile);
+  var gitignorePatterns = ignore(gitignoreFile);
+  var ignorePatterns = gitignorePatterns.filter(p => !p.startsWith('!'));
+  var exemptionPatterns = gitignorePatterns.filter(p => p.startsWith('!'));
 
   var isMatch = function(fp) {
-    return mm.any(fp, ignorePatterns, opts);
+    return !mm.any(fp, exemptionPatterns, opts) && mm.any(fp, ignorePatterns, opts);
   };
 
   return function gitignore(file) {


### PR DESCRIPTION
Having exceptions to the rules in your .gitignore files, i.e. lines starting with an exclamation mark, leads to this middleware matching basically anything and flagging all files to be excluded.

Fix: isMatch should return false, if one of the exception pattern matches.